### PR TITLE
Added depends_on to cloudtrail creation

### DIFF
--- a/aws/cloudtrail/config.tf
+++ b/aws/cloudtrail/config.tf
@@ -1,6 +1,9 @@
 resource "aws_cloudtrail" "cloudtrail" {
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}"
   cloud_watch_logs_role_arn     = "${aws_iam_role.cloudwatch_logs.arn}"
+  depends_on                    = [
+    "aws_s3_bucket_policy.cloudtrail"
+  ]
   enable_log_file_validation    = true
   include_global_service_events = true
   is_multi_region_trail         = true


### PR DESCRIPTION
The policy must be applied before creating the cloudtrail. Adding the depends_on stops a race condition.