### PR TITLE
reverted previous

### DIFF
--- a/aws/lambda/-input.tf
+++ b/aws/lambda/-input.tf
@@ -13,11 +13,6 @@ variable "handler" {
   type = "string"
 }
 
-variable "ignore_version_changes" {
-  default = "false"
-  type    = "string"
-}
-
 variable "kms_key_arn" {
   type = "string"
 }

--- a/aws/lambda/config.tf
+++ b/aws/lambda/config.tf
@@ -86,7 +86,7 @@ resource "aws_lambda_function" "function" {
   kms_key_arn       = "${var.kms_key_arn}"
   lifecycle {
     ignore_changes = [
-      "${var.ignore_version_changes == "true" ? "s3_object_version" : ""}"
+      "s3_object_version"
     ]
   }
   memory_size       = "${var.memory_size}"


### PR DESCRIPTION
and hardcoded ignoring version changes. This is an unfortunate hack required b/c you can’t interpolate the lifecycle stuff. However, this is needed for most CD situations, where the version of the fuction code will change apart from TF.