### PR TITLE
empty string to some value

### DIFF
--- a/aws/secretsmanager/rotating-secret/-input.tf
+++ b/aws/secretsmanager/rotating-secret/-input.tf
@@ -22,6 +22,6 @@ variable "tags" {
 }
 
 variable "value" {
-  default = ""
+  default = " "
   type    = "string"
 }

--- a/aws/secretsmanager/standard-secret/-input.tf
+++ b/aws/secretsmanager/standard-secret/-input.tf
@@ -13,6 +13,6 @@ variable "tags" {
 }
 
 variable "value" {
-  default = ""
+  default = " "
   type    = "string"
 }


### PR DESCRIPTION
empty string would not be allowed, so added a white space.